### PR TITLE
dpdk22.11 enable deprecated KNI device

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         include:
           - image: ubuntu2204-dpdk2211
-          - image: ubuntu2004-dpdk2111
-          - image: ubuntu2004-dpdk2011
 
     steps:
       - name: Checkout code

--- a/Dockerfile-ubuntu2204-dpdk2211
+++ b/Dockerfile-ubuntu2204-dpdk2211
@@ -32,4 +32,4 @@ RUN wget http://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.gz \
   && tar xvzf dpdk-${DPDK_VERSION}.tar.gz \
   && rm -rf dpdk-${DPDK_VERSION}.tar.gz \
   && mv dpdk-stable-${DPDK_VERSION} dpdk && cd dpdk \
-  && meson build && cd build && ninja && ninja install && ldconfig
+  && meson build -Ddisable_libs= && cd build && ninja && ninja install && ldconfig


### PR DESCRIPTION
With this the library KNI is enabled

#8 5.251 lib/meson.build:149: WARNING: Enabling deprecated library, "kni"