### PR TITLE
Rhel bump cmake

### DIFF
--- a/scripts/rhel_install.sh
+++ b/scripts/rhel_install.sh
@@ -17,6 +17,7 @@ dnf upgrade -y && dnf install -y --allowerasing \
   git \
   libpcap-devel \
   libstdc++-static \
+  openssl-devel \
   pkg-config \
   python3-devel \
   python3-pip \

--- a/scripts/rhel_install.sh
+++ b/scripts/rhel_install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+CMAKE_VERSION="3.28.3"
 
 echo "Install DNF for RedHat Enterprise Linux:${RHEL_VERSION}"
 
@@ -27,3 +28,11 @@ dnf upgrade -y && dnf install -y --allowerasing \
 
 # Install pytest
 python3 -m pip install pytest
+
+# Update CMake (3.22+ required for packaging)
+wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
+	&& tar xzf cmake-${CMAKE_VERSION}.tar.gz \
+	&& cd cmake-${CMAKE_VERSION} \
+	&& ./bootstrap --prefix=/usr/local \
+	&& make -j$(nproc) && make install \
+	&& cd .. && rm -rf cmake-${CMAKE_VERSION}*


### PR DESCRIPTION
We need CMake 3.22+ to properly package PcapPlusPlus
RHEL 9 is shipped with 3.20.1