### PR TITLE
Add `gawk` to Fedora image

### DIFF
--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -7,6 +7,7 @@ dnf upgrade -y && dnf install -y \
   ccache \
   cmake \
   curl \
+  gawk \
   gcc-c++ \
   git \
   libpcap-devel \
@@ -19,7 +20,6 @@ dnf upgrade -y && dnf install -y \
   net-tools \
   tcpreplay \
   python3-virtualenv \
-  gawk \
   && dnf groupinstall -y 'Development Tools'
 
 # Install pytest

--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -19,6 +19,7 @@ dnf upgrade -y && dnf install -y \
   net-tools \
   tcpreplay \
   python3-virtualenv \
+  gawk \
   && dnf groupinstall -y 'Development Tools'
 
 # Install pytest


### PR DESCRIPTION
PcapPlusPlus tests fail because `awk` is missing on this image: https://github.com/seladb/PcapPlusPlus/actions/runs/14564033138/job/40850796706?pr=1780