### PR TITLE
Add missing packages for ubuntu2004

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            image: fedora42
+            image: ubuntu2004
+          - runner: ubuntu-latest
+            image: ubuntu2004-zstd
           #- runner: ubuntu-latest
           #  image: ubuntu2404-dpdk2311
           #- runner: ubuntu-latest

--- a/Dockerfile-ubuntu2004
+++ b/Dockerfile-ubuntu2004
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get -y install \
   doxygen \
   git \
   libpcap-dev \
+  libxml2-dev \
+  libxslt-dev \
   pkg-config \
   python3-pip \
   software-properties-common \

--- a/Dockerfile-ubuntu2004-zstd
+++ b/Dockerfile-ubuntu2004-zstd
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get -y install \
   doxygen \
   git \
   libpcap-dev \
+  libxml2-dev \
+  libxslt-dev \
   pkg-config \
   python3-pip \
   software-properties-common \


### PR DESCRIPTION
Fixes cobertura report generation for Ubuntu 20.04. https://github.com/seladb/PcapPlusPlus/pull/1852